### PR TITLE
Integrate placeholder support for item names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,7 +147,7 @@ tasks {
         downloadPlugins {
             url("https://github.com/dmulloy2/ProtocolLib/releases/download/5.4.0/ProtocolLib.jar")
         }
-        minecraftVersion("1.20.4")
+        minecraftVersion("1.21.8")
     }
 
     shadowJar {

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -66,7 +66,7 @@ public class OraxenPlugin extends JavaPlugin {
     public static JarFile getJarFile() {
         try {
             return new JarFile(oraxen.getFile());
-        } catch (IOException e) {
+        } catch (final IOException e) {
             return null;
         }
     }
@@ -105,6 +105,7 @@ public class OraxenPlugin extends JavaPlugin {
         hudManager = new HudManager(configsManager);
         fontManager = new FontManager(configsManager);
         soundManager = new SoundManager(configsManager.getSound());
+        CompatibilitiesManager.enableNativeCompatibilities();
         OraxenItems.loadItems();
         fontManager.registerEvents();
         fontManager.verifyRequired(); // Verify the required glyph is there
@@ -121,9 +122,8 @@ public class OraxenPlugin extends JavaPlugin {
         postLoading();
         try {
             Message.PLUGIN_LOADED.log(AdventureUtils.tagResolver("os", OS.getOs().getPlatformName()));
-        } catch (Exception ignore) {
+        } catch (final Exception ignore) {
         }
-        CompatibilitiesManager.enableNativeCompatibilities();
         if (VersionUtil.isCompiled())
             NoticeUtils.compileNotice();
         if (VersionUtil.isLeaked())
@@ -140,7 +140,7 @@ public class OraxenPlugin extends JavaPlugin {
     public void onDisable() {
         HandlerList.unregisterAll(this);
         FurnitureFactory.unregisterEvolution();
-        for (Player player : Bukkit.getOnlinePlayers())
+        for (final Player player : Bukkit.getOnlinePlayers())
             if (GlyphHandlers.isNms())
                 NMSHandlers.getHandler().glyphHandler().uninject(player);
 

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -124,6 +124,7 @@ public class OraxenPlugin extends JavaPlugin {
             Message.PLUGIN_LOADED.log(AdventureUtils.tagResolver("os", OS.getOs().getPlatformName()));
         } catch (final Exception ignore) {
         }
+        CompatibilitiesManager.enableWorldEditCompatibilities();
         if (VersionUtil.isCompiled())
             NoticeUtils.compileNotice();
         if (VersionUtil.isLeaked())

--- a/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -8,6 +8,7 @@ import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.arguments.TextArgument;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.ItemUpdater;
@@ -16,8 +17,6 @@ import io.th0rgal.oraxen.utils.ItemUtils;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-
-import com.comphenix.protocol.error.Report;
 
 import java.util.Collection;
 import java.util.Map;
@@ -116,7 +115,7 @@ public class CommandsManager {
 
                     for (final Player target : targets) {
                         for (final ItemStack item : items) {
-                            final Map<Integer, ItemStack> output = target.getInventory().addItem(io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases.setPlaceholders(target, item.clone(), true));
+                            final Map<Integer, ItemStack> output = target.getInventory().addItem(PapiAliases.updateLore(target, item.clone()));
                             if (!output.isEmpty()) {
                                 for (final ItemStack stack : output.values()) {
                                     target.getWorld().dropItem(target.getLocation(), stack);
@@ -157,7 +156,7 @@ public class CommandsManager {
 
                     for (final Player target : targets) {
                         final Map<Integer, ItemStack> output = target.getInventory()
-                                .addItem(io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases.setPlaceholders(target, ItemUpdater.updateItem(itemBuilder.build()).clone(), true));
+                                .addItem(PapiAliases.updateLore(target, ItemUpdater.updateItem(itemBuilder.build()).clone()));
                         if (!output.isEmpty()) {
                             for (final ItemStack stack : output.values()) {
                                 target.getWorld().dropItem(target.getLocation(), stack);

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/CompatibilitiesManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/CompatibilitiesManager.java
@@ -15,19 +15,23 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class CompatibilitiesManager {
 
-    private CompatibilitiesManager() {}
+    private CompatibilitiesManager() {
+    }
 
     private static final ConcurrentHashMap<String, Class<? extends CompatibilityProvider<?>>> COMPATIBILITY_PROVIDERS = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, CompatibilityProvider<?>> ACTIVE_COMPATIBILITY_PROVIDERS = new ConcurrentHashMap<>();
 
     public static void enableNativeCompatibilities() {
-        WrappedWorldEdit.init();
-        WrappedWorldEdit.registerParser();
         new CompatibilityListener();
         addCompatibility("PlaceholderAPI", PlaceholderAPICompatibility.class, true);
         addCompatibility("BossShopPro", BossShopProCompatibility.class, true);
         addCompatibility("MythicMobs", MythicMobsCompatibility.class, true);
         addCompatibility("BlockLocker", BlockLockerCompatibility.class, true);
+    }
+
+    public static void enableWorldEditCompatibilities() {
+        WrappedWorldEdit.init();
+        WrappedWorldEdit.registerParser();
     }
 
     public static void disableCompatibilities() {
@@ -48,7 +52,8 @@ public class CompatibilitiesManager {
                 Message.PLUGIN_HOOKS.log(AdventureUtils.tagResolver("plugin", pluginName));
                 return true;
             }
-        } catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+        } catch (final InstantiationException | IllegalAccessException | NoSuchMethodException |
+                       InvocationTargetException e) {
             e.printStackTrace();
             return false;
         }
@@ -110,7 +115,7 @@ public class CompatibilitiesManager {
         return ACTIVE_COMPATIBILITY_PROVIDERS;
     }
 
-    public static boolean hasPlugin(String name) {
+    public static boolean hasPlugin(final String name) {
         return PluginUtils.isEnabled(name);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/PapiAliases.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/PapiAliases.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.compatibilities.provided.placeholderapi;
 
-import io.th0rgal.oraxen.utils.VersionUtil;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -12,7 +11,13 @@ import java.util.List;
 
 public class PapiAliases {
 
-    private PapiAliases() {}
+    private PapiAliases() {
+    }
+
+    @NotNull
+    public static String setPlaceholders(final String text) {
+        return PlaceholderAPI.setPlaceholders(null, text);
+    }
 
     @NotNull
     public static String setPlaceholders(final Player player, final String text) {
@@ -28,20 +33,14 @@ public class PapiAliases {
     @Contract("_, _, _ -> param2")
     public static ItemStack setPlaceholders(final Player player, @NotNull final ItemStack item, final boolean updateLore) {
         if (item.hasItemMeta()) {
-            final ItemMeta meta = item.getItemMeta();
-            if (meta.hasDisplayName())
-                meta.setDisplayName(setPlaceholders(player, meta.getDisplayName()));
-            if (VersionUtil.atOrAbove("1.21") && meta.hasItemName()) {
-                meta.setItemName(setPlaceholders(player, meta.getItemName()));
-            }
-
             if (updateLore) {
+                final ItemMeta meta = item.getItemMeta();
                 final List<String> itemLore = meta.getLore();
                 if (itemLore != null && !itemLore.isEmpty()) {
                     meta.setLore(setPlaceholders(player, itemLore));
                 }
+                item.setItemMeta(meta);
             }
-            item.setItemMeta(meta);
         }
         return item;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/PapiAliases.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/PapiAliases.java
@@ -15,32 +15,25 @@ public class PapiAliases {
     }
 
     @NotNull
-    public static String setPlaceholders(final String text) {
-        return PlaceholderAPI.setPlaceholders(null, text);
-    }
-
-    @NotNull
     public static String setPlaceholders(final Player player, final String text) {
         return PlaceholderAPI.setPlaceholders(player, text);
     }
 
     @NotNull
-    public static List<String> setPlaceholders(final Player player, final List<String> text) {
-        return PlaceholderAPI.setPlaceholders(player, text);
+    public static String setPlaceholders(final String text) {
+        return PlaceholderAPI.setPlaceholders(null, text);
     }
 
     @NotNull
-    @Contract("_, _, _ -> param2")
-    public static ItemStack setPlaceholders(final Player player, @NotNull final ItemStack item, final boolean updateLore) {
+    @Contract("_, _ -> param2")
+    public static ItemStack updateLore(final Player player, @NotNull final ItemStack item) {
         if (item.hasItemMeta()) {
-            if (updateLore) {
-                final ItemMeta meta = item.getItemMeta();
-                final List<String> itemLore = meta.getLore();
-                if (itemLore != null && !itemLore.isEmpty()) {
-                    meta.setLore(setPlaceholders(player, itemLore));
-                }
-                item.setItemMeta(meta);
+            final ItemMeta meta = item.getItemMeta();
+            final List<String> itemLore = meta.getLore();
+            if (itemLore != null && !itemLore.isEmpty()) {
+                meta.setLore(PlaceholderAPI.setPlaceholders(player, itemLore));
             }
+            item.setItemMeta(meta);
         }
         return item;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
 import io.th0rgal.oraxen.compatibilities.provided.mmoitems.WrappedMMOItem;
 import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
+import io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
@@ -175,9 +176,11 @@ public class ItemParser {
 
     private void parseDataComponents(final ItemBuilder item) {
         final ConfigurationSection section = mergeWithTemplateSection();
-        if (section.contains("itemname") && VersionUtil.atOrAbove("1.20.5"))
-            item.setItemName(section.getString("itemname"));
-        else if (section.contains("displayname")) item.setDisplayName(section.getString("displayname"));
+        if (section.contains("itemname") && VersionUtil.atOrAbove("1.20.5")) {
+            item.setItemName(PapiAliases.setPlaceholders(section.getString("itemname")));
+        } else if (section.contains("displayname")) {
+            item.setDisplayName(PapiAliases.setPlaceholders(section.getString("displayname")));
+        }
 
         final ConfigurationSection components = section.getConfigurationSection("Components");
         if (components == null || !VersionUtil.atOrAbove("1.20.5")) return;

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
@@ -338,7 +338,6 @@ public class ItemUpdater implements Listener {
                 nmsHandler.consumableComponent(newItem, Optional.ofNullable(nmsHandler.consumableComponent(newItem)).orElse(nmsHandler.consumableComponent(oldItem)))
         );
 
-        io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases.setPlaceholders(null, newItem, false);
         return newItem;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
@@ -5,6 +5,7 @@ import dev.triumphteam.gui.guis.GuiItem;
 import dev.triumphteam.gui.guis.PaginatedGui;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.ItemUpdater;
@@ -101,7 +102,7 @@ public class ItemsView {
             final GuiItem guiItem = new GuiItem(itemStack);
             guiItem.setAction(e -> {
                 final Player player = (Player) e.getWhoClicked();
-                player.getInventory().addItem(io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PapiAliases.setPlaceholders(player, ItemUpdater.updateItem(guiItem.getItemStack().clone()), true));
+                player.getInventory().addItem(PapiAliases.updateLore(player, ItemUpdater.updateItem(guiItem.getItemStack().clone())));
             });
             gui.addItem(guiItem);
         }


### PR DESCRIPTION
Added usage of PapiAliases.setPlaceholders to parseDataComponents in ItemParser to support PlaceholderAPI in itemname and displayname fields. Also refactored PapiAliases to provide a setPlaceholders method for non-player contexts and adjusted lore updating logic.